### PR TITLE
Add FastAPI API, CLI, and usage docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,24 @@
+# FinQ Usage
+
+## API
+
+Start the server using the CLI:
+
+```bash
+python -m finq.cli serve
+```
+
+Then call the API using an API key:
+
+```bash
+export FINQ_API_KEY=secret
+curl -H "X-API-Key: secret" http://localhost:8000/quote/AAPL
+```
+
+## Command Line
+
+Fetch a quote directly from the command line:
+
+```bash
+python -m finq.cli quote AAPL
+```

--- a/src/finq/__init__.py
+++ b/src/finq/__init__.py
@@ -1,0 +1,3 @@
+"""Core FinQ package."""
+
+__all__ = []

--- a/src/finq/api/__init__.py
+++ b/src/finq/api/__init__.py
@@ -1,0 +1,14 @@
+"""FinQ API package exposing the FastAPI application."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .auth import APIKeyMiddleware
+from .routes import router
+
+
+app = FastAPI(title="FinQ API")
+app.add_middleware(APIKeyMiddleware)
+app.include_router(router)
+
+__all__ = ["app"]

--- a/src/finq/api/auth.py
+++ b/src/finq/api/auth.py
@@ -1,0 +1,21 @@
+"""Authentication middleware for the FinQ API."""
+from __future__ import annotations
+
+import os
+
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """Simple API key authentication middleware."""
+
+    def __init__(self, app, api_key: str | None = None) -> None:
+        super().__init__(app)
+        self.api_key = api_key or os.getenv("FINQ_API_KEY", "secret")
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        key = request.headers.get("X-API-Key")
+        if key != self.api_key:
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+        return await call_next(request)

--- a/src/finq/api/routes.py
+++ b/src/finq/api/routes.py
@@ -1,0 +1,18 @@
+"""FastAPI routers for FinQ services."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ..service_adapters import QuoteService
+
+router = APIRouter(prefix="/quote", tags=["quote"])
+
+
+def get_quote_service() -> QuoteService:
+    return QuoteService()
+
+
+@router.get("/{ticker}")
+async def read_quote(ticker: str, service: QuoteService = Depends(get_quote_service)):
+    """Return quote data for the given ticker."""
+    return service.get_quote(ticker)

--- a/src/finq/cli.py
+++ b/src/finq/cli.py
@@ -1,0 +1,33 @@
+"""Command line interface for FinQ."""
+from __future__ import annotations
+
+import click
+import uvicorn
+
+from .service_adapters import QuoteService
+
+
+@click.group()
+def cli() -> None:
+    """Entry point for FinQ commands."""
+
+
+@cli.command()
+@click.argument("ticker")
+def quote(ticker: str) -> None:
+    """Fetch a quote for ``TICKER`` and print the price."""
+    service = QuoteService()
+    data = service.get_quote(ticker)
+    click.echo(f"{data['ticker']}: {data['price']}")
+
+
+@cli.command()
+@click.option("--host", default="127.0.0.1", show_default=True)
+@click.option("--port", default=8000, show_default=True, type=int)
+def serve(host: str, port: int) -> None:
+    """Run the FinQ API server."""
+    uvicorn.run("finq.api:app", host=host, port=port)
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/finq/service_adapters.py
+++ b/src/finq/service_adapters.py
@@ -1,0 +1,16 @@
+"""Service adapters providing financial data access."""
+from __future__ import annotations
+
+from typing import Dict
+
+
+class QuoteService:
+    """Adapter to retrieve stock quote data.
+
+    For demonstration, this returns static data.
+    In a real implementation, this would call an external API.
+    """
+
+    def get_quote(self, ticker: str) -> Dict[str, float]:
+        """Return a static quote for the given ticker symbol."""
+        return {"ticker": ticker.upper(), "price": 100.0}


### PR DESCRIPTION
## Summary
- Implement FastAPI app with quote route and API key auth middleware
- Provide Click-based CLI for serving API and fetching quotes
- Add usage documentation for API calls and CLI commands

## Testing
- `python -m py_compile $(find src -name '*.py')`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68950c33d344833380dd481e9c400be1