### PR TITLE
Add onboarding home screen

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -55,11 +55,21 @@ class RequestHandler(BaseHTTPRequestHandler):
     <h1>Welcome to FinQ</h1>
     <p>Select an onboarding task to get started:</p>
     <ul>
-      <li><a href=\"/onboarding/accounting\">Link to accounting software</a></li>
-      <li><a href=\"/onboarding/bank\">Link to bank</a></li>
-      <li><a href=\"/onboarding/data\">Link to data sources</a></li>
-      <li><a href=\"/onboarding/business\">Describe business</a></li>
-      <li><a href=\"/onboarding/goals\">Determine goals</a></li>
+      <li>
+        <a href=\"/onboarding/accounting\">Link to accounting software</a>
+      </li>
+      <li>
+        <a href=\"/onboarding/bank\">Link to bank</a>
+      </li>
+      <li>
+        <a href=\"/onboarding/data\">Link to data sources</a>
+      </li>
+      <li>
+        <a href=\"/onboarding/business\">Describe business</a>
+      </li>
+      <li>
+        <a href=\"/onboarding/goals\">Determine goals</a>
+      </li>
     </ul>
   </body>
 </html>

--- a/api/routes.py
+++ b/api/routes.py
@@ -13,6 +13,10 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         parsed = urlparse(self.path)
+        if parsed.path in ("/", "", "/index.html"):
+            self._send_homepage()
+            return
+
         parts = parsed.path.strip("/").split("/")
         if len(parts) != 2:
             self.send_error(404, "Not found")
@@ -34,6 +38,34 @@ class RequestHandler(BaseHTTPRequestHandler):
         body = json.dumps({"symbol": symbol.upper(), "price": price}).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_homepage(self) -> None:
+        """Serve a simple HTML onboarding home screen."""
+        body = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\"utf-8\">
+    <title>FinQ Onboarding</title>
+  </head>
+  <body>
+    <h1>Welcome to FinQ</h1>
+    <p>Select an onboarding task to get started:</p>
+    <ul>
+      <li><a href=\"/onboarding/accounting\">Link to accounting software</a></li>
+      <li><a href=\"/onboarding/bank\">Link to bank</a></li>
+      <li><a href=\"/onboarding/data\">Link to data sources</a></li>
+      <li><a href=\"/onboarding/business\">Describe business</a></li>
+      <li><a href=\"/onboarding/goals\">Determine goals</a></li>
+    </ul>
+  </body>
+</html>
+""".strip().encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)

--- a/src/finq/ai_services/forecasting.py
+++ b/src/finq/ai_services/forecasting.py
@@ -13,7 +13,7 @@ class ForecastingService(BaseService):
     def __init__(self) -> None:
         self.model: Any = None
 
-    def authenticate(self, *args, **kwargs) -> None:  # pragma: no cover - no auth needed
+    def authenticate(self, *args, **kwargs) -> None:  # pragma: no cover
         """Prophet does not require authentication."""
         return None
 
@@ -22,7 +22,9 @@ class ForecastingService(BaseService):
         try:
             from prophet import Prophet
         except Exception as exc:  # pragma: no cover - dependency optional
-            raise RuntimeError("prophet package is required for ForecastingService") from exc
+            raise RuntimeError(
+                "prophet package is required for ForecastingService"
+            ) from exc
 
         self.model = Prophet()
         self.model.fit(df)

--- a/src/finq/ai_services/llm.py
+++ b/src/finq/ai_services/llm.py
@@ -11,7 +11,11 @@ from .base import BaseService
 class LLMChatService(BaseService):
     """Adapter for OpenAI-style chat completion models."""
 
-    def __init__(self, model: str = "gpt-3.5-turbo", client: Optional[Any] = None) -> None:
+    def __init__(
+        self,
+        model: str = "gpt-3.5-turbo",
+        client: Optional[Any] = None,
+    ) -> None:
         self.model = model
         self.client = client
         self.api_key: Optional[str] = None
@@ -23,7 +27,9 @@ class LLMChatService(BaseService):
             try:
                 import openai  # type: ignore
             except Exception as exc:  # pragma: no cover - dependency optional
-                raise RuntimeError("openai package is required for LLMChatService") from exc
+                raise RuntimeError(
+                    "openai package is required for LLMChatService"
+                ) from exc
             openai.api_key = self.api_key
             self.client = openai
 

--- a/src/finq/ai_services/ocr.py
+++ b/src/finq/ai_services/ocr.py
@@ -26,7 +26,8 @@ class OCRSummarizerService(BaseService):
             from PIL import Image
         except Exception as exc:  # pragma: no cover
             raise RuntimeError(
-                "pytesseract and pillow packages are required for OCRSummarizerService"
+                "pytesseract and pillow packages are required for "
+                "OCRSummarizerService"
             ) from exc
 
         text = pytesseract.image_to_string(Image.open(image_path))

--- a/src/finq/api/auth.py
+++ b/src/finq/api/auth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 
-from fastapi import HTTPException, Request
+from fastapi import HTTPException, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
@@ -14,8 +14,12 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.api_key = api_key or os.getenv("FINQ_API_KEY", "secret")
 
-    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+    async def dispatch(
+        self, request: Request, call_next
+    ) -> Response:  # type: ignore[override]
         key = request.headers.get("X-API-Key")
         if key != self.api_key:
-            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+            raise HTTPException(
+                status_code=401, detail="Invalid or missing API key"
+            )
         return await call_next(request)

--- a/src/finq/api/routes.py
+++ b/src/finq/api/routes.py
@@ -13,6 +13,9 @@ def get_quote_service() -> QuoteService:
 
 
 @router.get("/{ticker}")
-async def read_quote(ticker: str, service: QuoteService = Depends(get_quote_service)):
+async def read_quote(
+    ticker: str,
+    service: QuoteService = Depends(get_quote_service),
+):
     """Return quote data for the given ticker."""
     return service.get_quote(ticker)

--- a/src/finq/service_registry.py
+++ b/src/finq/service_registry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Registry for dynamically loading FinQ services."""
 
 from importlib import import_module
-from typing import Any, Dict, Type
+from typing import Dict, Type
 
 from .ai_services.base import BaseService
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,3 +45,11 @@ def test_read_crypto_price():
 def test_read_crypto_price_not_found():
     status, _ = make_request("/crypto/UNKNOWN")
     assert status == 404
+
+
+def test_homepage_links():
+    status, data = make_request("/")
+    assert status == 200
+    body = data.decode()
+    assert "Link to accounting software" in body
+    assert "Link to bank" in body


### PR DESCRIPTION
## Summary
- serve a simple HTML onboarding page at the API root with links to key tasks
- test that the onboarding links are returned by the server

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68952020b23c8333bb333ac9183050b6